### PR TITLE
Fix dark mode link contrast on website content links

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -336,6 +336,17 @@ body {
   margin-bottom: 1.5rem;
 }
 
+.section p a {
+  color: var(--link-color);
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 0.08em;
+  transition: opacity 0.2s ease;
+}
+
+.section p a:hover {
+  opacity: 0.85;
+}
+
 .features-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));


### PR DESCRIPTION
### Motivation
- Prevent inline links in content from blending into the dark theme by giving them an explicit readable color and clearer affordance.

### Description
- Add `.section p a` rules in `docs/styles.css` to use `var(--link-color)`, set `text-underline-offset` and `text-decoration-thickness`, and add a subtle hover opacity transition to improve visibility and feedback.

### Testing
- No automated unit tests cover documentation styling; the CSS was checked for syntax/parse issues and the change was inspected in the stylesheet (no parse errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c59cf37424832b8aaa1a1abdf3a473)